### PR TITLE
Add serde support via feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,14 @@ version = "0.6.2"
 harness = false
 name = "parse"
 
+[features]
+default = []
+
 [dependencies]
 fnv = "1.0.6"
 lazy_static = "1.3.0"
+serde = { version = "1.0.115", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.2.10"
+serde_json = "1.0.57"

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -110,6 +110,7 @@ const USER_INFO_CHAR_MAP: [u8; 256] = [
 /// Any conversions to a string will **not** hide the password component of the authority. Be
 /// careful if you decide to perform logging.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Authority<'authority> {
     /// The host component of the authority as defined in
     /// [[RFC3986, Section 3.2.2](https://tools.ietf.org/html/rfc3986#section-3.2.2)].
@@ -764,6 +765,7 @@ impl<'authority> TryFrom<&'authority str> for Authority<'authority> {
 /// mean that the host is normalized. If the host needs to be normalized, use the
 /// [`Host::normalize`] function.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Host<'host> {
     /// An IPv4 address. Based on the `std`'s implementation, leading zeros for octets are allowed
     /// for up to three digits. So for example, `"000.000.000.000"` is still considered a valid IPv4
@@ -1065,6 +1067,7 @@ impl<'host> TryFrom<&'host str> for Host<'host> {
 /// mean that the password is normalized. If the password needs to be normalized, use the
 /// [`Password::normalize`] function.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Password<'password> {
     /// Whether the password is normalized.
     normalized: bool,
@@ -1309,6 +1312,7 @@ impl<'password> TryFrom<&'password str> for Password<'password> {
 /// mean that the host is normalized. If the registered name needs to be normalized, use the
 /// [`RegisteredName::normalize`] function.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegisteredName<'name> {
     /// Whether the registered name is normalized.
     normalized: bool,
@@ -1549,6 +1553,7 @@ impl<'name> TryFrom<&'name str> for RegisteredName<'name> {
 /// mean that the username is normalized. If the username needs to be normalized, use the
 /// [`Username::normalize`] function.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Username<'username> {
     /// Whether the username is normalized.
     normalized: bool,

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -48,6 +48,7 @@ const FRAGMENT_CHAR_MAP: [u8; 256] = [
 /// mean that the fragment is normalized. If the fragment needs to be normalized, use the
 /// [`Fragment::normalize`] function.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fragment<'fragment> {
     /// The internal fragment source that is either owned or borrowed.
     fragment: Cow<'fragment, str>,

--- a/src/path.rs
+++ b/src/path.rs
@@ -55,6 +55,7 @@ const PATH_CHAR_MAP: [u8; 256] = [
 /// normalized, use either the [`Path::normalize`] or [`Segment::normalize`] functions,
 /// respectively.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Path<'path> {
     /// whether the path is absolute. Specifically, a path is absolute if it starts with a
     /// `'/'`.
@@ -707,6 +708,7 @@ impl<'path> TryFrom<&'path str> for Path<'path> {
 ///
 /// Segments are separated from other segments with the `'/'` delimiter.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Segment<'segment> {
     /// Whether the segment is normalized.
     normalized: bool,

--- a/src/query.rs
+++ b/src/query.rs
@@ -52,6 +52,7 @@ const QUERY_CHAR_MAP: [u8; 256] = [
 /// mean that the query is normalized. If the query needs to be normalized, use the
 /// [`Query::normalize`] function.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Query<'query> {
     /// Whether the query is normalized.
     normalized: bool,

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -80,6 +80,7 @@ macro_rules! schemes {
         /// An unregistered scheme is case-insensitive. Furthermore, percent-encoding is not allowed
         /// in schemes.
         #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[non_exhaustive]
         pub enum Scheme<'scheme> {
         $(
@@ -359,6 +360,7 @@ impl<'scheme> TryFrom<&'scheme str> for Scheme<'scheme> {
 ///
 /// This is case-insensitive, and this is reflected in the equality and hash functions.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnregisteredScheme<'scheme> {
     /// Whether the fragment is normalized.
     normalized: bool,

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -27,6 +27,7 @@ use crate::uri_reference::{URIReference, URIReferenceBuilder, URIReferenceError}
 ///
 /// A URI is a URI reference, one with a scheme.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct URI<'uri> {
     /// All URIs are also URI references, so we just maintain a [`URIReference`] underneath.
     uri_reference: URIReference<'uri>,
@@ -1594,5 +1595,22 @@ mod test {
         test_case("g#s/./x", "http://a/b/c/g#s/./x");
         test_case("g#s/../x", "http://a/b/c/g#s/../x");
         test_case("http:g", "http:g");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        let uri = URI::try_from("http://a/b/c/d;p?q").unwrap();
+
+        // Perform serialization
+        let json_string = serde_json::to_string(&uri).unwrap();
+
+        // Perform deserialization
+        let uri2 = serde_json::from_str(&json_string).unwrap();
+
+        assert_eq!(
+            uri, uri2,
+            "Information lost in serialization/deserialization"
+        );
     }
 }

--- a/src/uri_reference.rs
+++ b/src/uri_reference.rs
@@ -14,6 +14,7 @@ use crate::scheme::{parse_scheme, Scheme, SchemeError};
 ///
 /// Specifically, a URI reference is either a URI or a relative reference (a schemeless URI).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct URIReference<'uri> {
     /// The authority component of the URI reference as defined in
     /// [[RFC3986, Section 3.2]](https://tools.ietf.org/html/rfc3986#section-3.2).


### PR DESCRIPTION
Resolves #9 by adding an optional feature for serde. If provided, all required structs/enums are compiled with serde derive for Serialize and Deserialize. You can build this with `cargo build --all-features` and test this with `cargo test --all-features` or specifically `cargo test --all-features test_serde`, which does a quick serialize and deserialize of a `URI` struct and then checks for equality.

@sgodwincs, personally, I'm a fan of keeping things simple through the derive approach, rather than you needing to write a custom serializer/deserializer. I wasn't sure if there was anything in your structs or enums that would require a custom serializer. At least for serde_json, this does not seem to be the case. I did not try it with more picky formats like bincode, though.