### PR TITLE
feature: All structs are ported to use smol_str::SmolStr for owned variant…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default = []
 fnv = "1.0.7"
 lazy_static = "1.4.0"
 serde = { version = "1.0.115", features = ["derive"], optional = true }
+smol_str = "0.1.22"
 
 [dev-dependencies]
 criterion = "0.2.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod scheme;
 pub mod uri;
 pub mod uri_reference;
 
+mod smol_str_cow;
+
 pub use self::authority::{
     Authority, AuthorityError, Host, HostError, Password, PasswordError, PortError, RegisteredName,
     RegisteredNameError, Username, UsernameError,

--- a/src/path.rs
+++ b/src/path.rs
@@ -9,8 +9,6 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::str;
 
-use smol_str::SmolStr;
-
 use crate::smol_str_cow::SmolStrCow;
 use crate::utility::{
     get_percent_encoded_value, normalize_string, percent_encoded_equality, percent_encoded_hash,
@@ -739,7 +737,7 @@ impl Segment<'_> {
     pub fn as_borrowed(&self) -> Segment {
         Segment {
             normalized: self.normalized,
-            segment: SmolStrCow::Borrowed(self.segment.deref()),
+            segment: SmolStrCow::from(self.segment.deref()),
         }
     }
 
@@ -771,7 +769,7 @@ impl Segment<'_> {
     pub fn empty() -> Segment<'static> {
         Segment {
             normalized: true,
-            segment: SmolStrCow::Borrowed(""),
+            segment: SmolStrCow::from(""),
         }
     }
 
@@ -786,7 +784,7 @@ impl Segment<'_> {
     pub fn into_owned(self) -> Segment<'static> {
         Segment {
             normalized: self.normalized,
-            segment: SmolStrCow::Owned(self.segment.into_owned()),
+            segment: SmolStrCow::from(self.segment.into_owned()),
         }
     }
 
@@ -906,10 +904,10 @@ impl Segment<'_> {
     pub fn normalize(&mut self) {
         if !self.normalized {
             // Unsafe: Paths must be valid ASCII-US, so this is safe.
-            let mut normalized_str = self.segment.to_string();
-            unsafe { normalize_string(&mut normalized_str, true) };
+            let mut normalized_segment = self.segment.to_string();
+            unsafe { normalize_string(&mut normalized_segment, true) };
 
-            self.segment = SmolStrCow::Owned(SmolStr::from(&normalized_str));
+            self.segment = SmolStrCow::from(normalized_segment);
             self.normalized = true;
         }
     }

--- a/src/smol_str_cow.rs
+++ b/src/smol_str_cow.rs
@@ -23,6 +23,27 @@ impl<'s> Deref for SmolStrCow<'s> {
     }
 }
 
+impl<'s> From<&'s str> for SmolStrCow<'s> {
+    #[inline]
+    fn from(v: &'s str) -> Self {
+        Self::Borrowed(v)
+    }
+}
+
+impl From<String> for SmolStrCow<'static> {
+    #[inline]
+    fn from(v: String) -> Self {
+        Self::Owned(SmolStr::from(&v))
+    }
+}
+
+impl From<SmolStr> for SmolStrCow<'static> {
+    #[inline]
+    fn from(v: SmolStr) -> Self {
+        Self::Owned(v)
+    }
+}
+
 impl<'s> SmolStrCow<'s> {
     /// Clone the data into an owned-type.
     #[inline]

--- a/src/smol_str_cow.rs
+++ b/src/smol_str_cow.rs
@@ -1,0 +1,76 @@
+use smol_str::SmolStr;
+use std::ops::Deref;
+
+/// A clone-on-write string container with
+///
+/// - `&str` for `Borrowed` case
+/// - `SmolStr` for `Owned` case
+#[derive(Debug, Clone)]
+pub enum SmolStrCow<'s> {
+    Borrowed(&'s str),
+    Owned(SmolStr),
+}
+
+impl<'s> Deref for SmolStrCow<'s> {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Borrowed(s) => *s,
+            SmolStrCow::Owned(s) => s.deref(),
+        }
+    }
+}
+
+impl<'s> SmolStrCow<'s> {
+    /// Clone the data into an owned-type.
+    #[inline]
+    pub fn into_owned(&self) -> SmolStr {
+        SmolStr::from(self.deref())
+    }
+}
+
+/// serde Serialize implementation
+#[cfg(feature = "serde")]
+impl<'s> serde::Serialize for SmolStrCow<'s> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.deref())
+    }
+}
+
+/// visitor for serde DeSerialize implementation
+#[cfg(feature = "serde")]
+struct SmolStrCowVisitor;
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Visitor<'de> for SmolStrCowVisitor {
+    type Value = SmolStrCow<'static>;
+
+    #[inline]
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    #[inline]
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(SmolStrCow::Owned(SmolStr::from(value)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'s, 'de> serde::Deserialize<'de> for SmolStrCow<'s> {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(SmolStrCowVisitor)
+    }
+}


### PR DESCRIPTION
It addresses #21 

It uses [`smol_str::SmolStr`](https://docs.rs/crate/smol_str/latest) as string invariant for owned segment, and `&str` for borrowed.

`smol_str` is dependable, as it is maintained by rust_analyzer team, and used in it extensively.