### PR TITLE
Add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Scott Godwin <sgodwincs@gmail.com>"]
 categories = ["parsing"]
 description = "A URI parser including relative references"
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/sgodwincs/uriparse-rs"
 license = "MIT"
 name = "uriparse"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -13,5 +13,13 @@ fn main() {
     for uri in args {
         let parsed = uriparse::URIReference::try_from(uri.as_str());
         println!("<{}>: {:#?}", uri, parsed);
+
+        if let Ok(parsed) = parsed {
+            let reconstructed = format!("{}", parsed);
+            if reconstructed != uri {
+                println!("Warning: URI doesn't round-trip -- serializes into:");
+                println!("<{}>", reconstructed);
+            }
+        }
     }
 }

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,0 +1,17 @@
+use std::env;
+
+fn main() {
+    let mut args = env::args();
+    let argv0 = args.next()
+        .expect("First argument is always present");
+
+    if args.size_hint().1 == Some(0) {
+        eprintln!("No URIs were given on the command line.");
+        eprintln!("Try running this as `{} http://example.com:1234/hello ../../path`", argv0);
+    }
+
+    for uri in args {
+        let parsed = uriparse::URIReference::try_from(uri.as_str());
+        println!("<{}>: {:#?}", uri, parsed);
+    }
+}


### PR DESCRIPTION
I find it easy to get familiar with a parsing crate if I can just toss it a few strings and see what it makes of them.

This PR adds an example that allows doing this easily right after cloning. (I think it might also help for issue reporting -- for example, in #6 I could state that "Running `cargo run --example cli -- 'coap://[fe80::1%eth0]/'` returns an InvalidIPv6Character rather than having an "eth0" zone in IPv6Address variant").