### PR TITLE
Add support for zone identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Scott Godwin <sgodwincs@gmail.com>"]
 categories = ["parsing"]
 description = "A URI parser including relative references"
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/sgodwincs/uriparse-rs"
 license = "MIT"
 name = "uriparse"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -13,5 +13,13 @@ fn main() {
     for uri in args {
         let parsed = uriparse::URIReference::try_from(uri.as_str());
         println!("<{}>: {:#?}", uri, parsed);
+
+        if let Ok(parsed) = parsed {
+            let reconstructed = format!("{}", parsed);
+            if reconstructed != uri {
+                println!("Warning: URI doesn't round-trip -- serializes into:");
+                println!("<{}>", reconstructed);
+            }
+        }
     }
 }

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,0 +1,17 @@
+use std::env;
+
+fn main() {
+    let mut args = env::args();
+    let argv0 = args.next()
+        .expect("First argument is always present");
+
+    if args.size_hint().1 == Some(0) {
+        eprintln!("No URIs were given on the command line.");
+        eprintln!("Try running this as `{} http://example.com:1234/hello ../../path`", argv0);
+    }
+
+    for uri in args {
+        let parsed = uriparse::URIReference::try_from(uri.as_str());
+        println!("<{}>: {:#?}", uri, parsed);
+    }
+}

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -1021,8 +1021,12 @@ impl<'host> TryFrom<&'host [u8]> for Host<'host> {
                 let zone = split_for_zone.next()
                     .unwrap_or(b"");
 
-                if !check_ipv6(ipv6) || !check_zone(zone) {
+                if !check_ipv6(ipv6) {
                     return Err(HostError::InvalidIPv6Character);
+                }
+
+                if !check_zone(zone) {
+                    return Err(HostError::InvalidZoneCharacter);
                 }
 
                 // Unsafe: The function above [`check_ipv6`] ensures this is valid ASCII-US.
@@ -1935,6 +1939,10 @@ pub enum HostError {
     /// character.
     InvalidIPv6Character,
 
+    /// The zone identifier (inside an IPv6 address after the `%`) contained characters other than
+    /// the allowed (which are the "unreserved" set).
+    InvalidZoneCharacter,
+
     /// The syntax for an IPv6 literal was used (i.e. `"[...]"`) and all of the characters were
     /// valid IPv6 characters. However, the format of the literal was invalid.
     InvalidIPv6Format,
@@ -1957,6 +1965,7 @@ impl Display for HostError {
             }
             InvalidIPv6Character => write!(formatter, "invalid host IPv6 character"),
             InvalidIPv6Format => write!(formatter, "invalid host IPv6 format"),
+            InvalidZoneCharacter => write!(formatter, "invalid character in zone ID"),
             InvalidIPvFutureCharacter => write!(formatter, "invalid host IPvFuture character"),
         }
     }


### PR DESCRIPTION
Closes: https://github.com/sgodwincs/uriparse-rs/issues/6

This is based on #25, please only consider the top commit. (But I'm using that PR in testing already; sadly there seems to be no way to tell GitHub that it's dependent on that PR). If #25 does get rejected, I can rebase it to get rid of those changes -- otherwise I think it's best to merge after it, and then things would be easy.

The implementation already follows https://datatracker.ietf.org/doc/draft-ietf-6man-rfc6874bis/ (the upcoming revision of RFC6874) in that it doesn't do any percent encoding of the percent sign.

As zone identifiers are necessarily non-empty, a URI with an IPv6 address without zone identifier is represented by an empty string as a zone identifier.

## Testing

```shell
$ cargo run --example cli -- 'coap://[fe80::1%eth0]/'
<coap://[fe80::1%eth0]/>: Ok(
    URIReference {
        authority: Some(
            Authority {
                host: IPv6Address(
                    fe80::1,
                    "eth0",
                ),
                password: None,
                port: None,
                username: None,
            },
        ),
        fragment: None,
        path: Path {
            absolute: true,
            double_dot_segment_count: 0,
            leading_double_dot_segment_count: 0,
            segments: [
                Segment {
                    normalized: true,
                    segment: "",
                },
            ],
            single_dot_segment_count: 0,
            unnormalized_count: 0,
        },
        query: None,
        scheme: Some(
            CoAP,
        ),
    },
)
```

## API

Given that the `enum Host` variants are exhaustive, this is an API breaking change -- and I don't see how it could be made non-breaking.