### PR TITLE
Add support for no-std mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Scott Godwin <sgodwincs@gmail.com>"]
-categories = ["parsing"]
+categories = ["parsing", "no-std"]
 description = "A URI parser including relative references"
 edition = "2021"
 homepage = "https://github.com/sgodwincs/uriparse-rs"
@@ -16,11 +16,13 @@ name = "parse"
 
 [features]
 default = []
+std = ["fnv/std", "lazy_static/spin", "serde?/std"]
 
 [dependencies]
-fnv = "1.0.7"
-lazy_static = "1.4.0"
-serde = { version = "1.0.115", features = ["derive"], optional = true }
+fnv = { version = "1.0.7", default-features = false }
+hashbrown = { version = "0.13" }
+lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
+serde = { version = "1.0.115", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.2.10"

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -22,15 +22,17 @@
 //! comes down to it just being too expensive to do a proper host comparison. To do so would require
 //! conversion to [`IpAddr`], which in the case of [`Ipv6Addr`] can be expensive.
 
-use std::borrow::Cow;
-use std::convert::{Infallible, TryFrom};
-use std::error::Error;
-use std::fmt::{self, Display, Formatter, Write};
-use std::hash::{Hash, Hasher};
-use std::mem;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::ops::Deref;
-use std::str;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::convert::{Infallible, TryFrom};
+use core::error::Error;
+use core::fmt::{self, Display, Formatter, Write};
+use core::hash::{Hash, Hasher};
+use core::mem;
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::ops::Deref;
+use core::str;
 
 use crate::utility::{
     get_percent_encoded_value, normalize_string, percent_encoded_equality, percent_encoded_hash,

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -2,13 +2,15 @@
 //!
 //! See [[RFC3986, Section 3.5](https://tools.ietf.org/html/rfc3986#section-3.5)].
 
-use std::borrow::Cow;
-use std::convert::{Infallible, TryFrom};
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-use std::str;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::convert::{Infallible, TryFrom};
+use core::error::Error;
+use core::fmt::{self, Display, Formatter};
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
+use core::str;
 
 use crate::utility::{
     get_percent_encoded_value, normalize_string, percent_encoded_equality, percent_encoded_hash,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 mod utility;
 
 pub mod authority;

--- a/src/path.rs
+++ b/src/path.rs
@@ -2,13 +2,16 @@
 //!
 //! See [[RFC3986, Section 3.3](https://tools.ietf.org/html/rfc3986#section-3.3)].
 
-use std::borrow::Cow;
-use std::convert::{Infallible, TryFrom};
-use std::error::Error;
-use std::fmt::{self, Display, Formatter, Write};
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-use std::str;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::convert::{Infallible, TryFrom};
+use core::error::Error;
+use core::fmt::{self, Display, Formatter, Write};
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
+use core::str;
 
 use crate::utility::{
     get_percent_encoded_value, normalize_string, percent_encoded_equality, percent_encoded_hash,

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,13 +6,15 @@
 //! string as defined by the RFC. You will need to use another crate (e.g.
 //! [queryst](https://github.com/rustless/queryst)) if you want it parsed.
 
-use std::borrow::Cow;
-use std::convert::{Infallible, TryFrom};
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-use std::str;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::convert::{Infallible, TryFrom};
+use core::error::Error;
+use core::fmt::{self, Display, Formatter};
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
+use core::str;
 
 use crate::utility::{
     get_percent_encoded_value, normalize_string, percent_encoded_equality, percent_encoded_hash,

--- a/src/relative_reference.rs
+++ b/src/relative_reference.rs
@@ -1,6 +1,8 @@
-use std::convert::{Infallible, TryFrom};
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
+use alloc::string::String;
+use alloc::string::ToString;
+use core::convert::{Infallible, TryFrom};
+use core::error::Error;
+use core::fmt::{self, Display, Formatter};
 
 use crate::authority::{Authority, AuthorityError, Host, Password, Username};
 use crate::fragment::{Fragment, FragmentError};

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -6,15 +6,17 @@
 //! the listed schemes, see
 //! [iana.org](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml).
 
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::convert::{Infallible, TryFrom};
+use core::error::Error;
+use core::fmt::{self, Display, Formatter};
+use core::hash::{Hash, Hasher};
+use core::str;
 use fnv::FnvBuildHasher;
+use hashbrown::HashMap;
 use lazy_static::lazy_static;
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::convert::{Infallible, TryFrom};
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
-use std::hash::{Hash, Hasher};
-use std::str;
 
 use crate::utility::normalize_string;
 

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -11,9 +11,11 @@
 //! use [`URI`], but if you want relative references (e.g. `"/"` in a GET request) use
 //! [`RelativeReference`]. If you can accept both, then use [`URIReference`].
 
-use std::convert::{Infallible, TryFrom};
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
+use alloc::string::String;
+use alloc::string::ToString;
+use core::convert::{Infallible, TryFrom};
+use core::error::Error;
+use core::fmt::{self, Display, Formatter};
 
 use crate::authority::{Authority, AuthorityError, Host, Password, Username};
 use crate::fragment::{Fragment, FragmentError};

--- a/src/uri_reference.rs
+++ b/src/uri_reference.rs
@@ -1,7 +1,9 @@
-use std::convert::{Infallible, TryFrom};
-use std::error::Error;
-use std::fmt::{self, Display, Formatter, Write};
-use std::mem;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::convert::{Infallible, TryFrom};
+use core::error::Error;
+use core::fmt::{self, Display, Formatter, Write};
+use core::mem;
 
 use crate::authority::{parse_authority, Authority, AuthorityError, Host, Password, Username};
 use crate::fragment::{Fragment, FragmentError};

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,4 +1,5 @@
-use std::hash::{Hash, Hasher};
+use alloc::string::String;
+use core::hash::{Hash, Hasher};
 
 #[rustfmt::skip]
 pub const UNRESERVED_CHAR_MAP: [u8; 256] = [
@@ -192,8 +193,8 @@ pub fn percent_encoded_equality(left: &[u8], right: &[u8], case_sensitive: bool)
 
 #[cfg(test)]
 mod test {
-    use std::collections::hash_map::RandomState;
-    use std::hash::BuildHasher;
+    use hashbrown::hash_map::DefaultHashBuilder;
+    use core::hash::BuildHasher;
 
     use super::*;
 
@@ -249,7 +250,7 @@ mod test {
             left_hash == right_hash
         }
 
-        let state = RandomState::new();
+        let state = DefaultHashBuilder::new();
 
         // Case sensitive
 


### PR DESCRIPTION
..by switching out imports from the std library in favor of their analogs in core library, and hashing imports in favor of hashbrown.


Having a no_std mode would be helpful for my use case. Please let me know about any concerns